### PR TITLE
fix(security): sanitize markdown rendering and harden Electron IPC bridge

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -6,6 +6,95 @@ import crypto from 'crypto'
 let mainWindow: BrowserWindow | null = null
 const trustedHosts = new Set<string>()
 
+type NetFetchOptions = { method?: string; headers?: Record<string, string>; body?: string }
+
+interface NetFetchRule {
+  host: string
+  allowsPath: (pathname: string) => boolean
+  methods: Set<string>
+  allowBody: boolean
+  allowedHeaders: Set<string>
+}
+
+const MAX_FETCH_BODY_BYTES = 128 * 1024
+const MAX_FETCH_RESPONSE_BYTES = 2 * 1024 * 1024
+
+const NET_FETCH_RULES: NetFetchRule[] = [
+  {
+    host: 'clawhub.ai',
+    allowsPath: (pathname) => pathname.startsWith('/api/v1/'),
+    methods: new Set(['GET']),
+    allowBody: false,
+    allowedHeaders: new Set(['accept']),
+  },
+  {
+    host: 'wry-manatee-359.convex.cloud',
+    allowsPath: (pathname) => pathname === '/api/query' || pathname === '/api/action',
+    methods: new Set(['POST']),
+    allowBody: true,
+    allowedHeaders: new Set(['content-type', 'convex-client', 'accept']),
+  },
+]
+
+function resolveNetFetchRule(parsed: URL): NetFetchRule | null {
+  return NET_FETCH_RULES.find((rule) => rule.host === parsed.hostname && rule.allowsPath(parsed.pathname)) || null
+}
+
+function sanitizeNetFetchHeaders(headers: NetFetchOptions['headers'], allowed: Set<string>): Record<string, string> | undefined {
+  if (!headers) return undefined
+  const sanitized: Record<string, string> = {}
+  for (const [rawKey, rawValue] of Object.entries(headers)) {
+    if (typeof rawKey !== 'string' || typeof rawValue !== 'string') {
+      throw new Error('Invalid headers')
+    }
+    const key = rawKey.trim().toLowerCase()
+    if (!key || !allowed.has(key)) {
+      throw new Error(`Header not allowed: ${rawKey}`)
+    }
+    if (rawValue.length > 8192) {
+      throw new Error('Header value too long')
+    }
+    sanitized[key] = rawValue
+  }
+  return Object.keys(sanitized).length > 0 ? sanitized : undefined
+}
+
+function sanitizeNetFetchBody(body: unknown, allowBody: boolean, method: string): string | undefined {
+  if (body === undefined) return undefined
+  if (typeof body !== 'string') throw new Error('Invalid request body')
+  if (!allowBody || method !== 'POST') throw new Error('Request body is not allowed')
+  if (Buffer.byteLength(body, 'utf8') > MAX_FETCH_BODY_BYTES) {
+    throw new Error('Request body too large')
+  }
+  return body
+}
+
+function normalizeNetFetchRequest(url: string, options?: NetFetchOptions): { url: string; options: NetFetchOptions } {
+  if (typeof url !== 'string') throw new Error('Invalid URL')
+  if (url.length > 2048) throw new Error('URL too long')
+
+  const parsed = new URL(url)
+  if (parsed.protocol !== 'https:') throw new Error('Only HTTPS URLs are allowed')
+  if (parsed.username || parsed.password) throw new Error('Credentials in URL are not allowed')
+  if (parsed.port && parsed.port !== '443') throw new Error('Custom ports are not allowed')
+
+  const rule = resolveNetFetchRule(parsed)
+  if (!rule) throw new Error('URL is not allowed')
+
+  const method = (options?.method || 'GET').toUpperCase()
+  if (!rule.methods.has(method)) {
+    throw new Error(`Method not allowed: ${method}`)
+  }
+
+  const headers = sanitizeNetFetchHeaders(options?.headers, rule.allowedHeaders)
+  const body = sanitizeNetFetchBody(options?.body, rule.allowBody, method)
+
+  return {
+    url: parsed.toString(),
+    options: { method, headers, body },
+  }
+}
+
 // Path to persist trusted hosts
 function getTrustedHostsPath(): string {
   const userDataPath = app.getPath('userData')
@@ -330,33 +419,38 @@ ipcMain.handle('toolcall:openPopout', async (_event, params: {
   }
 })
 
-// Proxy fetch for CORS-restricted URLs (e.g. ClawHub API, Convex)
-ipcMain.handle('net:fetchUrl', async (_event, url: string, options?: { method?: string; headers?: Record<string, string>; body?: string }) => {
-  // Only allow https URLs
-  const parsed = new URL(url)
-  if (parsed.protocol !== 'https:') {
-    throw new Error('Only HTTPS URLs are allowed')
-  }
-
+// Proxy fetch for CORS-restricted URLs (limited to known ClawHub/Convex endpoints).
+ipcMain.handle('net:fetchUrl', async (_event, url: string, options?: NetFetchOptions) => {
+  const normalized = normalizeNetFetchRequest(url, options)
   const { net } = await import('electron')
+
   return new Promise<string>((resolve, reject) => {
     const request = net.request({
-      url,
-      method: options?.method || 'GET'
+      url: normalized.url,
+      method: normalized.options.method || 'GET',
     })
-    if (options?.headers) {
-      for (const [key, value] of Object.entries(options.headers)) {
+
+    if (normalized.options.headers) {
+      for (const [key, value] of Object.entries(normalized.options.headers)) {
         request.setHeader(key, value)
       }
     }
-    let body = ''
+
+    let responseText = ''
+    let responseSize = 0
     request.on('response', (response) => {
       response.on('data', (chunk) => {
-        body += chunk.toString()
+        const text = chunk.toString()
+        responseSize += Buffer.byteLength(text, 'utf8')
+        if (responseSize > MAX_FETCH_RESPONSE_BYTES) {
+          request.destroy(new Error('Response too large'))
+          return
+        }
+        responseText += text
       })
       response.on('end', () => {
         if (response.statusCode && response.statusCode >= 200 && response.statusCode < 300) {
-          resolve(body)
+          resolve(responseText)
         } else {
           reject(new Error(`HTTP ${response.statusCode}`))
         }
@@ -364,126 +458,12 @@ ipcMain.handle('net:fetchUrl', async (_event, url: string, options?: { method?: 
       response.on('error', reject)
     })
     request.on('error', reject)
-    if (options?.body) {
-      request.write(options.body)
+
+    if (normalized.options.body) {
+      request.write(normalized.options.body)
     }
     request.end()
   })
-})
-
-// Extract ZIP buffer to a target directory using pure Node.js (no external commands)
-async function extractZipToDir(zipBuffer: Buffer, targetDir: string): Promise<string[]> {
-  const fs = await import('fs/promises')
-  const path = await import('path')
-  const zlib = await import('zlib')
-  const extractedFiles: string[] = []
-
-  // Find End of Central Directory record (signature 0x06054b50)
-  let eocdOffset = -1
-  for (let i = zipBuffer.length - 22; i >= Math.max(0, zipBuffer.length - 65557); i--) {
-    if (zipBuffer.readUInt32LE(i) === 0x06054b50) {
-      eocdOffset = i
-      break
-    }
-  }
-  if (eocdOffset === -1) throw new Error('Invalid ZIP file: no end-of-central-directory record')
-
-  const cdEntries = zipBuffer.readUInt16LE(eocdOffset + 10)
-  const cdOffset = zipBuffer.readUInt32LE(eocdOffset + 16)
-
-  // Collect file entries from central directory
-  const entries: Array<{ fileName: string; compressionMethod: number; compressedSize: number; localHeaderOffset: number }> = []
-  let offset = cdOffset
-  for (let i = 0; i < cdEntries; i++) {
-    if (offset + 46 > zipBuffer.length) break
-    if (zipBuffer.readUInt32LE(offset) !== 0x02014b50) break
-
-    const compressionMethod = zipBuffer.readUInt16LE(offset + 10)
-    const compressedSize = zipBuffer.readUInt32LE(offset + 20)
-    const fileNameLength = zipBuffer.readUInt16LE(offset + 28)
-    const extraFieldLength = zipBuffer.readUInt16LE(offset + 30)
-    const commentLength = zipBuffer.readUInt16LE(offset + 32)
-    const localHeaderOffset = zipBuffer.readUInt32LE(offset + 42)
-    const fileName = zipBuffer.toString('utf8', offset + 46, offset + 46 + fileNameLength)
-    offset += 46 + fileNameLength + extraFieldLength + commentLength
-
-    if (fileName.includes('..') || path.isAbsolute(fileName)) continue
-    entries.push({ fileName, compressionMethod, compressedSize, localHeaderOffset })
-  }
-
-  // Strip common root directory prefix if all entries share one
-  const firstSlash = entries.length > 0 ? entries[0].fileName.indexOf('/') : -1
-  let stripPrefix = ''
-  if (firstSlash > 0) {
-    const candidate = entries[0].fileName.substring(0, firstSlash + 1)
-    if (entries.every(e => e.fileName.startsWith(candidate))) {
-      stripPrefix = candidate
-    }
-  }
-
-  // Extract files
-  for (const entry of entries) {
-    const relativeName = stripPrefix ? entry.fileName.substring(stripPrefix.length) : entry.fileName
-    if (!relativeName || relativeName.endsWith('/')) continue
-
-    const localFileNameLen = zipBuffer.readUInt16LE(entry.localHeaderOffset + 26)
-    const localExtraLen = zipBuffer.readUInt16LE(entry.localHeaderOffset + 28)
-    const dataOffset = entry.localHeaderOffset + 30 + localFileNameLen + localExtraLen
-
-    let fileData: Buffer
-    if (entry.compressionMethod === 0) {
-      fileData = zipBuffer.subarray(dataOffset, dataOffset + entry.compressedSize)
-    } else if (entry.compressionMethod === 8) {
-      const compressed = zipBuffer.subarray(dataOffset, dataOffset + entry.compressedSize)
-      fileData = zlib.inflateRawSync(compressed)
-    } else {
-      console.warn(`[clawhub] Skipping ${relativeName}: unsupported compression method ${entry.compressionMethod}`)
-      continue
-    }
-
-    const filePath = path.join(targetDir, relativeName)
-    await fs.mkdir(path.dirname(filePath), { recursive: true })
-    await fs.writeFile(filePath, fileData)
-    extractedFiles.push(relativeName)
-  }
-
-  return extractedFiles
-}
-
-// Download a ClawHub skill ZIP and extract to a target directory
-ipcMain.handle('clawhub:install', async (_event, slug: string, targetDir: string) => {
-  // Validate slug
-  if (!/^[a-zA-Z0-9_-]+$/.test(slug)) {
-    throw new Error(`Invalid skill slug: ${slug}`)
-  }
-
-  const fs = await import('fs/promises')
-
-  // Download ZIP from ClawHub API
-  const { net } = await import('electron')
-  const downloadUrl = `https://clawhub.ai/api/v1/download?slug=${encodeURIComponent(slug)}`
-  const zipBuffer = await new Promise<Buffer>((resolve, reject) => {
-    const request = net.request({ url: downloadUrl, method: 'GET' })
-    const chunks: Buffer[] = []
-    request.on('response', (response) => {
-      if (response.statusCode && (response.statusCode < 200 || response.statusCode >= 300)) {
-        reject(new Error(`Download failed: HTTP ${response.statusCode}`))
-        return
-      }
-      response.on('data', (chunk) => { chunks.push(chunk as Buffer) })
-      response.on('end', () => resolve(Buffer.concat(chunks)))
-      response.on('error', reject)
-    })
-    request.on('error', reject)
-    request.end()
-  })
-
-  // Remove existing skill dir if present, then extract
-  await fs.rm(targetDir, { recursive: true, force: true })
-  await fs.mkdir(targetDir, { recursive: true })
-  const extractedFiles = await extractZipToDir(zipBuffer, targetDir)
-
-  return { ok: true, files: extractedFiles }
 })
 
 // --- Ed25519 crypto (Node.js, since Chromium Web Crypto lacks Ed25519) ---

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,5 +1,93 @@
 import { contextBridge, ipcRenderer } from 'electron'
 
+type FetchOptions = { method?: string; headers?: Record<string, string>; body?: string }
+
+interface FetchRule {
+  host: string
+  allowsPath: (pathname: string) => boolean
+  methods: Set<string>
+  allowBody: boolean
+  allowedHeaders: Set<string>
+}
+
+const MAX_FETCH_BODY_BYTES = 128 * 1024
+
+const FETCH_RULES: FetchRule[] = [
+  {
+    host: 'clawhub.ai',
+    allowsPath: (pathname) => pathname.startsWith('/api/v1/'),
+    methods: new Set(['GET']),
+    allowBody: false,
+    allowedHeaders: new Set(['accept']),
+  },
+  {
+    host: 'wry-manatee-359.convex.cloud',
+    allowsPath: (pathname) => pathname === '/api/query' || pathname === '/api/action',
+    methods: new Set(['POST']),
+    allowBody: true,
+    allowedHeaders: new Set(['content-type', 'convex-client', 'accept']),
+  },
+]
+
+function resolveFetchRule(parsed: URL): FetchRule | null {
+  return FETCH_RULES.find((rule) => rule.host === parsed.hostname && rule.allowsPath(parsed.pathname)) || null
+}
+
+function sanitizeFetchHeaders(headers: FetchOptions['headers'], allowed: Set<string>): Record<string, string> | undefined {
+  if (!headers) return undefined
+  const sanitized: Record<string, string> = {}
+  for (const [rawKey, rawValue] of Object.entries(headers)) {
+    if (typeof rawKey !== 'string' || typeof rawValue !== 'string') {
+      throw new Error('Invalid headers')
+    }
+    const key = rawKey.trim().toLowerCase()
+    if (!key || !allowed.has(key)) {
+      throw new Error(`Header not allowed: ${rawKey}`)
+    }
+    if (rawValue.length > 8192) {
+      throw new Error('Header value too long')
+    }
+    sanitized[key] = rawValue
+  }
+  return Object.keys(sanitized).length > 0 ? sanitized : undefined
+}
+
+function sanitizeFetchBody(body: unknown, allowBody: boolean, method: string): string | undefined {
+  if (body === undefined) return undefined
+  if (typeof body !== 'string') throw new Error('Invalid request body')
+  if (!allowBody || method !== 'POST') throw new Error('Request body is not allowed')
+  if (Buffer.byteLength(body, 'utf8') > MAX_FETCH_BODY_BYTES) {
+    throw new Error('Request body too large')
+  }
+  return body
+}
+
+function normalizeFetchRequest(url: string, options?: FetchOptions): { url: string; options: FetchOptions } {
+  if (typeof url !== 'string') throw new Error('Invalid URL')
+  if (url.length > 2048) throw new Error('URL too long')
+
+  const parsed = new URL(url)
+  if (parsed.protocol !== 'https:') throw new Error('Only HTTPS URLs are allowed')
+  if (parsed.username || parsed.password) throw new Error('Credentials in URL are not allowed')
+  if (parsed.port && parsed.port !== '443') throw new Error('Custom ports are not allowed')
+
+  const rule = resolveFetchRule(parsed)
+  if (!rule) throw new Error('URL is not allowed')
+
+  const method = (options?.method || 'GET').toUpperCase()
+  if (!rule.methods.has(method)) {
+    throw new Error(`Method not allowed: ${method}`)
+  }
+
+  const headers = sanitizeFetchHeaders(options?.headers, rule.allowedHeaders)
+  const body = sanitizeFetchBody(options?.body, rule.allowBody, method)
+
+  return {
+    url: parsed.toString(),
+    options: { method, headers, body },
+  }
+}
+
 // Expose protected methods that allow the renderer process to use
 // the ipcRenderer without exposing the entire object
 contextBridge.exposeInMainWorld('electronAPI', {
@@ -15,8 +103,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('subagent:openPopout', params),
   openToolCallPopout: (params: { toolCallId: string; name: string }) =>
     ipcRenderer.invoke('toolcall:openPopout', params),
-  fetchUrl: (url: string, options?: { method?: string; headers?: Record<string, string>; body?: string }) => ipcRenderer.invoke('net:fetchUrl', url, options),
-  clawhubInstall: (slug: string, targetDir: string) => ipcRenderer.invoke('clawhub:install', slug, targetDir),
+  fetchUrl: (url: string, options?: FetchOptions) => {
+    const normalized = normalizeFetchRequest(url, options)
+    return ipcRenderer.invoke('net:fetchUrl', normalized.url, normalized.options)
+  },
   generateEd25519KeyPair: () => ipcRenderer.invoke('crypto:generateEd25519'),
   signEd25519: (privateKeyJwk: JsonWebKey, payload: string) => ipcRenderer.invoke('crypto:signEd25519', privateKeyJwk, payload),
   platform: process.platform
@@ -37,7 +127,6 @@ declare global {
       openSubagentPopout: (params: { sessionKey: string; serverUrl: string; authToken: string; authMode: string; label: string }) => Promise<void>
       openToolCallPopout: (params: { toolCallId: string; name: string }) => Promise<void>
       fetchUrl: (url: string, options?: { method?: string; headers?: Record<string, string>; body?: string }) => Promise<string>
-      clawhubInstall: (slug: string, targetDir: string) => Promise<{ ok: boolean; files: string[] }>
       generateEd25519KeyPair: () => Promise<{ id: string; publicKeyBase64url: string; privateKeyJwk: JsonWebKey }>
       signEd25519: (privateKeyJwk: JsonWebKey, payload: string) => Promise<string>
       platform: NodeJS.Platform

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' ws: wss: http: https:; img-src 'self' http: https: data:;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' ws: wss: http: https:; img-src 'self' http: https: data:; object-src 'none'; base-uri 'self'; frame-ancestors 'none';">
     <!-- Mobile app meta tags -->
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />

--- a/src/components/ChatArea.tsx
+++ b/src/components/ChatArea.tsx
@@ -4,13 +4,9 @@ import { Message, stripAnsi } from '../lib/openclaw'
 import { resolveToolDisplay, extractToolDetail } from '../lib/openclaw/tool-display'
 import { ToolIcon } from './ToolIcon'
 import { SubagentBlock } from './SubagentBlock'
+import { SafeMarkdown } from './SafeMarkdown'
 import { format, isSameDay } from 'date-fns'
-import { marked } from 'marked'
 import logoUrl from '../../build/icon.png'
-
-// Configure marked for chat-friendly rendering: single newlines become <br>,
-// GFM tables/strikethrough enabled, synchronous parsing.
-marked.setOptions({ breaks: true, gfm: true, async: false })
 
 export function ChatArea() {
   const { messages: allMessages, agents, currentAgentId, sessions, currentSessionId, activeSubagents, openSubagentPopout, openToolCallPopout } = useStore()
@@ -363,38 +359,6 @@ function ToolCallBlock({ toolCall, onOpenPopout }: { toolCall: ToolCall; onOpenP
   )
 }
 
-// Custom marked renderer that wraps fenced code blocks with a copy button
-const renderer = new marked.Renderer()
-const originalCode = renderer.code.bind(renderer)
-renderer.code = function (this: unknown, ...args: Parameters<typeof originalCode>) {
-  const html = originalCode.apply(this, args)
-  return `<div class="code-block-wrapper"><button class="code-copy-btn" type="button" aria-label="Copy code"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg></button>${html}</div>`
-}
-
 function MessageContent({ content }: { content: string }) {
-  const ref = useRef<HTMLDivElement>(null)
-  const html = useMemo(
-    () => marked.parse(stripAnsi(content), { async: false, renderer }) as string,
-    [content]
-  )
-
-  useEffect(() => {
-    const el = ref.current
-    if (!el) return
-    const handler = (e: MouseEvent) => {
-      const btn = (e.target as HTMLElement).closest('.code-copy-btn')
-      if (!btn) return
-      const wrapper = btn.closest('.code-block-wrapper')
-      const code = wrapper?.querySelector('code')
-      if (!code) return
-      navigator.clipboard.writeText(code.textContent || '').then(() => {
-        btn.classList.add('copied')
-        setTimeout(() => btn.classList.remove('copied'), 2000)
-      })
-    }
-    el.addEventListener('click', handler)
-    return () => el.removeEventListener('click', handler)
-  }, [html])
-
-  return <div className="markdown-content" ref={ref} dangerouslySetInnerHTML={{ __html: html }} />
+  return <SafeMarkdown content={content} />
 }

--- a/src/components/SafeMarkdown.tsx
+++ b/src/components/SafeMarkdown.tsx
@@ -1,0 +1,67 @@
+import { ComponentProps, ReactNode, isValidElement, useMemo, useState } from 'react'
+import ReactMarkdown, { Components } from 'react-markdown'
+import rehypeSanitize from 'rehype-sanitize'
+import remarkGfm from 'remark-gfm'
+import { stripAnsi } from '../lib/openclaw'
+
+function extractText(node: ReactNode): string {
+  if (typeof node === 'string' || typeof node === 'number') return String(node)
+  if (Array.isArray(node)) return node.map(extractText).join('')
+  if (isValidElement(node)) return extractText((node.props as { children?: ReactNode }).children)
+  return ''
+}
+
+function CopyablePre({ children, ...props }: ComponentProps<'pre'>) {
+  const [copied, setCopied] = useState(false)
+  const rawText = useMemo(() => extractText(children), [children])
+  const textToCopy = rawText.endsWith('\n') ? rawText.slice(0, -1) : rawText
+
+  const handleCopy = async () => {
+    try {
+      if (!textToCopy || !navigator.clipboard?.writeText) return
+      await navigator.clipboard.writeText(textToCopy)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Ignore clipboard errors (e.g., permission denied).
+    }
+  }
+
+  return (
+    <div className="code-block-wrapper">
+      <button
+        type="button"
+        className={`code-copy-btn${copied ? ' copied' : ''}`}
+        aria-label="Copy code"
+        onClick={handleCopy}
+      >
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <rect x="9" y="9" width="13" height="13" rx="2" />
+          <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+        </svg>
+      </button>
+      <pre {...props}>{children}</pre>
+    </div>
+  )
+}
+
+const markdownComponents: Components = {
+  pre: CopyablePre,
+}
+
+export function SafeMarkdown({ content }: { content: string }) {
+  const sanitized = useMemo(() => stripAnsi(content), [content])
+
+  return (
+    <div className="markdown-content">
+      <ReactMarkdown
+        skipHtml
+        remarkPlugins={[remarkGfm]}
+        rehypePlugins={[rehypeSanitize]}
+        components={markdownComponents}
+      >
+        {sanitized}
+      </ReactMarkdown>
+    </div>
+  )
+}

--- a/src/components/SubagentViewer.tsx
+++ b/src/components/SubagentViewer.tsx
@@ -2,9 +2,7 @@ import { useState, useRef, useEffect, useMemo } from 'react'
 import { OpenClawClient, Message, stripAnsi } from '../lib/openclaw'
 import { resolveToolDisplay, extractToolDetail } from '../lib/openclaw/tool-display'
 import { ToolIcon } from './ToolIcon'
-import { marked } from 'marked'
-
-marked.setOptions({ breaks: true, gfm: true, async: false })
+import { SafeMarkdown } from './SafeMarkdown'
 
 interface ToolCallInfo {
   toolCallId: string
@@ -221,11 +219,7 @@ function ViewerMessage({ message }: { message: Message }) {
 }
 
 function ViewerMarkdown({ content }: { content: string }) {
-  const html = useMemo(
-    () => marked.parse(stripAnsi(content), { async: false }) as string,
-    [content]
-  )
-  return <div className="markdown-content" dangerouslySetInnerHTML={{ __html: html }} />
+  return <SafeMarkdown content={content} />
 }
 
 function ViewerToolCall({ toolCall }: { toolCall: ToolCallInfo }) {

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -377,18 +377,6 @@ export async function corsFetch(url: string, options?: { method?: string; header
   return await res.text()
 }
 
-// Download and install a ClawHub skill to a target directory (Electron only)
-export async function clawhubInstall(slug: string, targetDir: string): Promise<string[]> {
-  const platform = getPlatform()
-
-  if (platform === 'electron' && (window as any).electronAPI?.clawhubInstall) {
-    const result = await (window as any).electronAPI.clawhubInstall(slug, targetDir)
-    return result.files || []
-  }
-
-  throw new Error('Skill install is only supported in the desktop app')
-}
-
 // App visibility tracking
 let _appIsActive = true
 


### PR DESCRIPTION
## Summary
- Replace unsafe markdown HTML injection with a shared `SafeMarkdown` renderer (`react-markdown` + `remark-gfm` + `rehype-sanitize`).
- Remove all `dangerouslySetInnerHTML` and `marked` usage in chat/subagent message rendering paths.
- Harden `net:fetchUrl` IPC with strict allowlists (host/path/method/header/body) and request/response size limits.
- Remove unused high-risk ClawHub install IPC exposure/handler to reduce renderer attack surface.
- Tighten CSP by removing `unsafe-inline` from `script-src` and adding `object-src`, `base-uri`, and `frame-ancestors` restrictions.

## Security impact
This closes the primary XSS path in markdown message rendering and limits renderer-originated IPC abuse in Electron if renderer compromise happens.

## Validation
- `npm run typecheck`
- `npx eslint electron/main.ts electron/preload.ts src/components/ChatArea.tsx src/components/SubagentViewer.tsx src/components/SafeMarkdown.tsx src/lib/platform.ts`
- `npm run test:run` *(fails due to pre-existing test expectations in `src/lib/openclaw-client.test.ts`: listSessions/listAgents/listSkills/listCronJobs length assertions)*