### PR TITLE
Fix RBAC lockout: remove insecure auth and rely on device pairing

### DIFF
--- a/INTEGRATION_STRATEGY.md
+++ b/INTEGRATION_STRATEGY.md
@@ -68,7 +68,7 @@ Authentication uses a challenge/handshake flow immediately after the WebSocket c
     "maxProtocol": 3,
     "role": "operator",
     "client": {
-      "id": "gateway-client",
+      "id": "clawcontrol",
       "displayName": "ClawControl",
       "version": "1.0.0",
       "platform": "web",

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Pre-built Windows binaries are available on the [Releases](https://github.com/ja
 - WebSocket health checks to detect half-open connections
 - Auto-reconnect on send failure with error display
 - Fix for WebSocket reconnect dying silently after 5 retries
-- Insecure auth toggle for development servers
+- Device pairing + scoped RBAC handshake (Ed25519 device identity)
 - Collapsible connection settings that auto-collapse when connected
 
 **Fixes**
@@ -345,7 +345,7 @@ On connect, the server sends a `connect.challenge` event. The client responds wi
     minProtocol: 3,
     maxProtocol: 3,
     role: 'operator',
-    client: { id: 'gateway-client', displayName: 'ClawControl', version: '1.0.0' },
+    client: { id: 'clawcontrol', displayName: 'ClawControl', version: '1.2.0' },
     auth: { token: 'your-token' }  // or { password: 'your-password' }
   }
 }

--- a/scripts/test-connection.js
+++ b/scripts/test-connection.js
@@ -62,7 +62,7 @@ ws.on('message', (data) => {
         maxProtocol: 3,
         role: 'operator',
         client: {
-          id: 'gateway-client',
+          id: 'clawcontrol',
           displayName: 'ClawControl',
           version: '1.0.0',
           platform: 'web',

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -17,8 +17,6 @@ export function SettingsModal() {
     disconnect,
     connected,
     connecting,
-    insecureAuth,
-    setInsecureAuth,
     notificationsEnabled,
     setNotificationsEnabled,
     openServerSettings,
@@ -32,7 +30,6 @@ export function SettingsModal() {
   const [url, setUrl] = useState(serverUrl)
   const [mode, setMode] = useState(authMode)
   const [token, setToken] = useState(gatewayToken)
-  const [insecure, setInsecure] = useState(insecureAuth)
   const [error, setError] = useState('')
   const [showToken, setShowToken] = useState(false)
   const [connectionExpanded, setConnectionExpanded] = useState(!connected)
@@ -45,9 +42,8 @@ export function SettingsModal() {
     setUrl(serverUrl)
     setMode(authMode)
     setToken(gatewayToken)
-    setInsecure(insecureAuth)
     setConnectionExpanded(!connected)
-  }, [serverUrl, authMode, gatewayToken, insecureAuth, showSettings, connected])
+  }, [serverUrl, authMode, gatewayToken, showSettings, connected])
 
   // Reset connect phase when modal opens or connection succeeds
   useEffect(() => {
@@ -180,7 +176,6 @@ export function SettingsModal() {
     setServerUrl(trimmedUrl)
     setAuthMode(mode)
     setGatewayToken(trimmedToken)
-    setInsecureAuth(insecure)
 
     // Clear stored device token so the fresh gateway token is used immediately
     try {
@@ -349,27 +344,6 @@ export function SettingsModal() {
                   </button>
                 </div>
                 <span className="form-hint">Required if authentication is enabled on the server.</span>
-              </div>
-
-              <div className="form-group">
-                <label style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-                  <span style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-                    Insecure auth
-                    <span
-                      className="info-tooltip"
-                      data-tip="Skip device identity handshake and send only the gateway token. Only enable this if your server has allowInsecureAuth: true."
-                    >?</span>
-                  </span>
-                  <label className="toggle-switch" style={{ marginLeft: '8px' }}>
-                    <input
-                      type="checkbox"
-                      checked={insecure}
-                      onChange={(e) => setInsecure(e.target.checked)}
-                    />
-                    <span className="toggle-slider"></span>
-                  </label>
-                </label>
-                <span className="form-hint">Send only the gateway token with no device identity</span>
               </div>
 
               {error && <div className="form-error">{error}</div>}

--- a/src/lib/appMeta.ts
+++ b/src/lib/appMeta.ts
@@ -1,0 +1,14 @@
+// App metadata and OpenClaw client identity
+//
+// Keep these values centralized so the connect payload and device signature stay in sync.
+
+import pkg from '../../package.json'
+
+export const APP_NAME = 'ClawControl'
+export const APP_VERSION = pkg.version as string
+
+// Unique ID used in OpenClaw Gateway connect payloads.
+// NOTE: Must match the clientId embedded in the device challenge signature payload.
+export const OPENCLAW_CLIENT_ID = 'clawcontrol'
+export const OPENCLAW_CLIENT_MODE = 'ui'
+export const OPENCLAW_ROLE = 'operator'

--- a/src/lib/device-identity.ts
+++ b/src/lib/device-identity.ts
@@ -3,6 +3,7 @@
 
 import { Capacitor } from '@capacitor/core'
 import { Preferences } from '@capacitor/preferences'
+import { OPENCLAW_CLIENT_ID, OPENCLAW_CLIENT_MODE, OPENCLAW_ROLE } from './appMeta'
 
 const IDENTITY_KEY = 'clawcontrol-device-identity'
 const DEVICE_TOKEN_PREFIX = 'clawcontrol-device-token:'
@@ -170,9 +171,12 @@ export async function signChallenge(
   scopes: string[]
 ): Promise<DeviceConnectField> {
   const signedAt = Date.now()
-  const clientId = 'gateway-client'
-  const clientMode = 'ui'
-  const role = 'operator'
+
+  // These values must match the `connect` payload.
+  const clientId = OPENCLAW_CLIENT_ID
+  const clientMode = OPENCLAW_CLIENT_MODE
+  const role = OPENCLAW_ROLE
+
   const scopesStr = scopes.join(',')
 
   // v2 signing payload

--- a/src/lib/openclaw/client.ts
+++ b/src/lib/openclaw/client.ts
@@ -7,6 +7,8 @@ import type {
 } from './types'
 import type { DeviceIdentity, DeviceConnectField } from '../device-identity'
 import { signChallenge } from '../device-identity'
+import { APP_NAME, APP_VERSION, OPENCLAW_CLIENT_ID, OPENCLAW_CLIENT_MODE } from '../appMeta'
+import { getPlatform } from '../platform'
 import { stripAnsi, extractToolResultText, extractTextFromContent, extractImagesFromContent, isHeartbeatContent, isNoiseContent, stripSystemNotifications } from './utils'
 import * as sessionsApi from './sessions'
 import * as chatApi from './chat'
@@ -311,11 +313,11 @@ export class OpenClawClient {
         role: 'operator',
         scopes,
         client: {
-          id: 'gateway-client',
-          displayName: 'ClawControl',
-          version: '1.0.0',
-          platform: 'web',
-          mode: 'ui'
+          id: OPENCLAW_CLIENT_ID,
+          displayName: APP_NAME,
+          version: APP_VERSION,
+          platform: getPlatform(),
+          mode: OPENCLAW_CLIENT_MODE
         },
         caps: ['tool-events'],
         auth: this.token

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -51,8 +51,6 @@ interface AppState {
   setAuthMode: (mode: 'token' | 'password') => void
   gatewayToken: string
   setGatewayToken: (token: string) => void
-  insecureAuth: boolean
-  setInsecureAuth: (insecure: boolean) => void
   connected: boolean
   connecting: boolean
   client: OpenClawClient | null
@@ -260,8 +258,6 @@ export const useStore = create<AppState>()(
         set({ gatewayToken: token })
         Platform.saveToken(token).catch(() => { })
       },
-      insecureAuth: false,
-      setInsecureAuth: (insecure) => set({ insecureAuth: insecure }),
       connected: false,
       connecting: false,
       client: null,
@@ -1227,27 +1223,26 @@ export const useStore = create<AppState>()(
         }
 
         try {
-          const { authMode, insecureAuth } = get()
+          const { authMode } = get()
 
-          // Load or create device identity for Ed25519 challenge signing
+          // Load or create device identity for Ed25519 challenge signing.
+          // ClawControl no longer supports the insecure-auth bypass; always attempt pairing.
           let deviceIdentity: DeviceIdentity | null = null
-          if (!insecureAuth) {
-            try {
-              deviceIdentity = await getOrCreateDeviceIdentity()
-            } catch {
-              // Ed25519 unavailable — connect without device identity
-            }
+          try {
+            deviceIdentity = await getOrCreateDeviceIdentity()
+          } catch {
+            // Ed25519 unavailable — connect without device identity
+          }
 
-            // Check for a stored device token for this server
-            if (serverHost) {
-              try {
-                const storedDeviceToken = await getDeviceToken(serverHost)
-                if (storedDeviceToken) {
-                  effectiveToken = storedDeviceToken
-                }
-              } catch {
-                // Storage read failed
+          // Check for a stored device token for this server.
+          if (serverHost) {
+            try {
+              const storedDeviceToken = await getDeviceToken(serverHost)
+              if (storedDeviceToken) {
+                effectiveToken = storedDeviceToken
               }
+            } catch {
+              // Storage read failed
             }
           }
 
@@ -1889,7 +1884,6 @@ export const useStore = create<AppState>()(
         theme: state.theme,
         serverUrl: state.serverUrl,
         authMode: state.authMode,
-        insecureAuth: state.insecureAuth,
         sidebarCollapsed: state.sidebarCollapsed,
         collapsedSessionGroups: state.collapsedSessionGroups,
         thinkingEnabled: state.thinkingEnabled,

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -51,6 +51,13 @@ class MockWebSocket {
   static CLOSED = 3
 
   readyState = MockWebSocket.OPEN
+
+  // Match browser WebSocket instances which expose these constants
+  CONNECTING = MockWebSocket.CONNECTING
+  OPEN = MockWebSocket.OPEN
+  CLOSING = MockWebSocket.CLOSING
+  CLOSED = MockWebSocket.CLOSED
+
   onopen: ((event: Event) => void) | null = null
   onclose: ((event: CloseEvent) => void) | null = null
   onmessage: ((event: MessageEvent) => void) | null = null


### PR DESCRIPTION
Fixes #7.

- Remove the insecure-auth bypass toggle/path (no more allowInsecureAuth-dependent behavior).
- Always attempt Ed25519 device identity pairing + per-host device token.
- Update connect payload client id to 'clawcontrol' (kept in sync with device signature payload).
- Update docs/examples.

Notes:
- If Ed25519 is unavailable (unlikely in Electron), the client will attempt to connect without a device identity; servers that require pairing will reject with NOT_PAIRED and the UI will guide approval.

QA:
- Connect to Gateway v2026.2.19 with RBAC enabled using a root token.
- Verify scopes include operator.read and sessions/agents list loads.
- Verify Settings modal no longer exposes insecure auth toggle.
