### PR TITLE
Fix #11: macOS Universal binary (Intel + Apple Silicon)

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,8 +102,14 @@
     },
     "mac": {
       "target": [
-        "dmg",
-        "zip"
+        {
+          "target": "dmg",
+          "arch": ["universal"]
+        },
+        {
+          "target": "zip",
+          "arch": ["universal"]
+        }
       ],
       "icon": "build/icon.png",
       "category": "public.app-category.productivity"


### PR DESCRIPTION
Change electron-builder mac arch to 'universal' so built artifacts contain both x64 and arm64 slices. This lets Intel macs run the app natively.\n\nWhat I changed:\n- package.json: set build.mac.target.arch to ["universal"] for dmg and zip targets.\n\nWhy:\n- electron-builder supports 'universal' mac arch to produce a single .app containing both x86_64 and arm64 slices. Previously the package.json listed separate archs which can lead to per-arch artifacts instead of a universal binary.\n\nNotes & follow-ups:\n- Building a universal mac binary must be done on macOS build hosts (Xcode needed). If CI cannot produce universal directly, build x64 and arm64 separately and use @electron/universal to merge them.\n- If there are runtime issues after producing universal artifacts, we should also verify code signing and entitlements (not changed here).