### PR TITLE
fix(build): add universal binary support for macOS (fixes #11)

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
         "dmg",
         "zip"
       ],
+      "arch": ["universal"],
       "icon": "build/icon.png",
       "category": "public.app-category.productivity"
     },


### PR DESCRIPTION
This change updates the electron-builder mac build configuration to produce a universal macOS binary so the app runs on both Intel (x64) and Apple Silicon (arm64) Macs.\n\nProblem:\n- electron-builder defaulted to the current machine architecture (arm64 on Apple Silicon), producing an app that fails to run on Intel Macs with a "not supported on this Mac" error.\n\nFix:\n- Add `arch: ["universal"]` to the `mac` build config in package.json.\n\nIf we later encounter issues with electron-builder and universal builds, an alternative is to specify target objects that include both `x64` and `arm64` slices explicitly.\n\nThis resolves GitHub issue #11.