### PR TITLE
Fix crypto.randomUUID() not available in non-HTTPS browser contexts

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -231,7 +231,7 @@ export function SettingsModal() {
       setShowSettings(false)
       return
     } catch (err) {
-      // First attempt failed — retry once
+      // First attempt failed — store error and retry once
       setError(err instanceof Error ? err.message : 'Connection failed')
     }
 

--- a/src/lib/openclaw/chat.ts
+++ b/src/lib/openclaw/chat.ts
@@ -1,7 +1,7 @@
 // OpenClaw Client - Chat API Methods
 
 import type { Message, RpcCaller } from './types'
-import { stripAnsi, stripSystemNotifications, stripConversationMetadata, extractImagesFromContent, parseMediaTokens } from './utils'
+import { stripAnsi, stripSystemNotifications, stripConversationMetadata, extractImagesFromContent, parseMediaTokens, generateUUID } from './utils'
 
 export interface HistoryToolCall {
   toolCallId: string
@@ -305,7 +305,7 @@ export async function sendMessage(call: RpcCaller, params: {
   thinking?: boolean
   attachments?: ChatAttachmentInput[]
 }): Promise<{ sessionKey?: string }> {
-  const idempotencyKey = crypto.randomUUID()
+  const idempotencyKey = generateUUID()
   const payload: Record<string, unknown> = {
     message: params.content,
     idempotencyKey

--- a/src/lib/openclaw/sessions.ts
+++ b/src/lib/openclaw/sessions.ts
@@ -1,7 +1,7 @@
 // OpenClaw Client - Session API Methods
 
 import type { Session, RpcCaller } from './types'
-import { resolveSessionKey, toIsoTimestamp, isNoiseContent, stripAnsi } from './utils'
+import { resolveSessionKey, toIsoTimestamp, isNoiseContent, stripAnsi, generateUUID } from './utils'
 
 // Extract agentId from session key format "agent:{agentId}:{uuid}"
 function extractAgentIdFromKey(key?: string): string | undefined {
@@ -68,7 +68,7 @@ export async function createSession(agentId?: string): Promise<Session> {
   // In v3, sessions are created lazily on first message.
   // Generate a proper session key in the server's expected format.
   const agent = agentId || 'main'
-  const uniqueId = crypto.randomUUID()
+  const uniqueId = generateUUID()
   const key = `agent:${agent}:${uniqueId}`
   return {
     id: key,

--- a/src/lib/openclaw/utils.ts
+++ b/src/lib/openclaw/utils.ts
@@ -452,3 +452,19 @@ export function resolveAvatarUrl(avatar: string | undefined, agentId: string, ws
   // Invalid avatar (like single character from parsing error)
   return undefined
 }
+
+/**
+ * Generate a UUID v4 string.
+ * Uses crypto.randomUUID() when available, falls back to a simple implementation for older browsers.
+ */
+export function generateUUID(): string {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID()
+  }
+  // Fallback for browsers without crypto.randomUUID (e.g., non-HTTPS contexts)
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0
+    const v = c === 'x' ? r : (r & 0x3) | 0x8
+    return v.toString(16)
+  })
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
-import { OpenClawClient, Message, Session, Agent, Skill, CronJob, Hook, HooksConfig, AgentFile, CreateAgentParams, buildIdentityContent, stripBase64FromStreaming } from '../lib/openclaw'
+import { OpenClawClient, Message, Session, Agent, Skill, CronJob, Hook, HooksConfig, AgentFile, CreateAgentParams, buildIdentityContent, stripBase64FromStreaming, generateUUID } from '../lib/openclaw'
 import { NodeClient } from '../lib/node'
 import { getDefaultPermissions } from '../lib/node/command-catalog'
 import { getCommands } from '../lib/node/capability-registry'
@@ -477,7 +477,7 @@ export const useStore = create<AppState>()(
       serverProfiles: [],
       activeProfileId: null,
       addServerProfile: (profileData) => {
-        const id = crypto.randomUUID()
+        const id = generateUUID()
         const profile: ServerProfile = { id, ...profileData }
         set((state) => ({
           serverProfiles: [...state.serverProfiles, profile]
@@ -1778,7 +1778,7 @@ export const useStore = create<AppState>()(
         // Migration: create a default server profile from legacy single-server state
         const { serverProfiles, serverUrl: legacyUrl, gatewayToken: currentToken, authMode: currentMode, deviceName: currentName, pinnedSessionKeys, collapsedSessionGroups } = get()
         if (serverProfiles.length === 0 && legacyUrl) {
-          const id = crypto.randomUUID()
+          const id = generateUUID()
           const profile: ServerProfile = {
             id,
             name: 'Server 1',
@@ -1831,7 +1831,7 @@ export const useStore = create<AppState>()(
 
         // Prevent concurrent connect() calls (React StrictMode fires effects twice)
         if (connecting) {
-          return
+          throw new Error('Connection already in progress')
         }
 
         // Show settings if URL is not configured


### PR DESCRIPTION
- Add generateUUID() utility function with fallback for browsers without crypto.randomUUID()
- Replace crypto.randomUUID() calls in store/index.ts, sessions.ts, and chat.ts
- Fix connect() to throw error instead of silent return when already connecting

The crypto.randomUUID() API is only available in secure contexts (HTTPS). This fix allows the app to work in development (HTTP) environments.