### PR TITLE
Add Android release matrix + PR CI workflow

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,0 +1,65 @@
+name: Android CI
+
+on:
+  pull_request:
+    paths:
+      - 'android/**'
+      - 'capacitor.config.ts'
+      - 'vite.config.mobile.ts'
+      - 'scripts/fix-android-edge-to-edge.js'
+      - 'scripts/set-android-version.js'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'src/**'
+      - 'plugins/capacitor-native-websocket/**'
+      - '.github/workflows/android-ci.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: android-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  debug-build:
+    name: Build debug APK
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Setup JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Sync Android version from package.json
+        run: node scripts/set-android-version.js
+
+      - name: Build web + cap sync + edge-to-edge patch
+        run: npm run mobile:sync
+
+      - name: Build debug APK
+        run: cd android && ./gradlew assembleDebug
+
+      - name: Upload debug APK as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-debug-${{ github.event.pull_request.number || github.run_id }}.apk
+          path: android/app/build/outputs/apk/debug/app-debug.apk
+          retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,10 @@ jobs:
             artifacts: |
               release/*.AppImage
               release/*.deb
+          - os: ubuntu-latest
+            platform: android
+            artifacts: |
+              android/app/build/outputs/apk/release/ClawControl-*.apk
 
     steps:
       - name: Checkout
@@ -53,14 +57,100 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # ---------- Desktop build (mac / win / linux only) ----------
       - name: Build (${{ matrix.platform }})
+        if: matrix.platform != 'android'
         run: npm run build:${{ matrix.platform }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # ---------- Android build (android only) ----------
+      - name: Setup JDK 21
+        if: matrix.platform == 'android'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Setup Android SDK
+        if: matrix.platform == 'android'
+        uses: android-actions/setup-android@v3
+
+      - name: Setup Gradle
+        if: matrix.platform == 'android'
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Decode keystore
+        if: matrix.platform == 'android'
+        env:
+          KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          echo "$KEYSTORE_BASE64" | base64 -d > android/app/upload-keystore.jks
+          test -s android/app/upload-keystore.jks || { echo "Keystore decode produced empty file"; exit 1; }
+
+      - name: Sync Android version from package.json
+        if: matrix.platform == 'android'
+        run: node scripts/set-android-version.js
+
+      - name: Build web + cap sync + edge-to-edge patch
+        if: matrix.platform == 'android'
+        run: npm run mobile:sync
+
+      - name: Build release APK
+        if: matrix.platform == 'android'
+        env:
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: cd android && ./gradlew assembleRelease
+
+      - name: Build release AAB
+        if: matrix.platform == 'android'
+        env:
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: cd android && ./gradlew bundleRelease
+
+      - name: Rename APK to include version
+        if: matrix.platform == 'android'
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          mv android/app/build/outputs/apk/release/app-release.apk \
+             android/app/build/outputs/apk/release/ClawControl-${VERSION}.apk
+          ls -la android/app/build/outputs/apk/release/
+
+      # ---------- Attach artifacts to GitHub Release (all platforms) ----------
       - name: Upload to release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ inputs.tag || github.ref_name }}
           files: ${{ matrix.artifacts }}
           fail_on_unmatched_files: false
+
+      # ---------- Play Console upload (android only, after GitHub Release attach) ----------
+      - name: Upload AAB to Play Console
+        id: play_upload
+        if: matrix.platform == 'android'
+        continue-on-error: true
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: com.claw.control
+          releaseFiles: android/app/build/outputs/bundle/release/app-release.aab
+          track: production
+          status: draft
+
+      - name: AAB fallback artifact (on Play upload failure)
+        if: matrix.platform == 'android' && steps.play_upload.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: aab-fallback-${{ github.ref_name }}
+          path: android/app/build/outputs/bundle/release/app-release.aab
+          retention-days: 14
+
+      - name: Fail job if Play upload failed
+        if: matrix.platform == 'android' && steps.play_upload.outcome == 'failure'
+        run: |
+          echo "::error::Play Console upload failed. AAB attached as workflow artifact 'aab-fallback-${{ github.ref_name }}' for manual upload."
+          exit 1


### PR DESCRIPTION
## Summary

Phase 3 of the Android build pipeline (per [spec](docs/superpowers/specs/2026-06-08-android-build-pipeline-design.md) and [plan](docs/superpowers/plans/2026-06-08-android-build-pipeline.md)).

- **Extended `.github/workflows/release.yml`** with an `android` matrix entry that builds a signed APK (attached to the GitHub Release) and a signed AAB (uploaded as a production-track **draft** to Play Console for `com.claw.control`). Existing mac/win/linux jobs unchanged in behavior — only the build step gained an `if: matrix.platform != 'android'` guard.
- **Added `.github/workflows/android-ci.yml`**: a fork-safe PR check that compiles `assembleDebug` and uploads the APK as a 7-day workflow artifact. No secrets exposed; debug build only.

Both workflows use JDK 21 (Capacitor 8's `@capacitor/geolocation` requires `JavaVersion.VERSION_21`).

## Secrets (all 5 are populated in this repo)

- `ANDROID_KEYSTORE_BASE64` — base64-encoded upload keystore
- `ANDROID_KEYSTORE_PASSWORD`, `ANDROID_KEY_ALIAS`, `ANDROID_KEY_PASSWORD` — signing creds
- `PLAY_SERVICE_ACCOUNT_JSON` — Play Developer API service-account JSON (`analytics@still-protocol-486316-c0.iam.gserviceaccount.com`)

## Play upload flow

- Play upload step uses `continue-on-error: true` so a Play API hiccup never strands the APK (which is already attached to the GitHub Release at that point).
- On Play upload failure: the AAB is attached to the workflow run as `aab-fallback-<tag>` (14-day retention) for manual upload, and a final step `exit 1`s so the run shows red.
- Production track + `draft` status — nothing reaches end users until you click **Submit for review** in Play Console.

## Test plan

- [ ] `android-ci.yml` runs on this PR (it modifies `.github/workflows/android-ci.yml`, a triggering path) and uploads a `app-debug-<PR#>.apk` artifact.
- [ ] After merge, dry-run `release.yml` via `gh workflow run release.yml --ref main -f tag=v1.8.0` and verify:
  - APK lands on the `v1.8.0` GitHub Release as `ClawControl-1.8.0.apk`.
  - Play Console → `com.claw.control` → Production shows a new draft release with `versionCode 10800` and `versionName 1.8.0`.
- [ ] Discard the Play Console draft after the dry-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)