### PR TITLE
feat(mobile): collapse chat header into overflow (⋮) menu + v1.9.0

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "com.claw.control"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 10800
-        versionName "1.8.0"
+        versionCode 10900
+        versionName "1.9.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawcontrol",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Desktop and mobile client for OpenClaw AI assistant",
   "main": "dist-electron/main.js",
   "author": {

--- a/src/components/InputArea.tsx
+++ b/src/components/InputArea.tsx
@@ -96,7 +96,10 @@ export function InputArea() {
   const { sendMessage, abortChat, connected, client, draftMessage, setDraftMessage } = useStore()
   const isStreaming = useStore(selectIsStreaming)
   const platform = getPlatform()
-  const hideMediaButtons = platform === 'ios'
+  // Mic/voice button is hidden on native mobile (iOS + Android); desktop and web
+  // keep it since speech recognition works there. The attach button is shown on
+  // every platform, docked inside the composer field.
+  const hideVoiceButton = platform === 'ios' || platform === 'android'
 
   const maxLength = 4000
 
@@ -779,47 +782,45 @@ export function InputArea() {
         </div>
       )}
       <div className="input-container">
-        {!hideMediaButtons && (
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept="image/*"
-            multiple
-            onChange={handleFileSelected}
-            style={{ display: 'none' }}
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          multiple
+          onChange={handleFileSelected}
+          style={{ display: 'none' }}
+        />
+        <div className="composer-field">
+          <textarea
+            ref={textareaRef}
+            value={message}
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+            onFocus={handleTextareaFocus}
+            onBlur={handleTextareaBlur}
+            onCompositionStart={handleCompositionStart}
+            onCompositionEnd={handleCompositionEnd}
+            placeholder="Type a message or /"
+            rows={1}
+            aria-label="Message input"
+            data-testid="message-input"
+            autoCorrect="on"
+            autoCapitalize="sentences"
+            spellCheck={true}
           />
-        )}
-        {!hideMediaButtons && (
           <button
-            className="attach-btn"
+            className="attach-inline-btn"
             onClick={handleAttachClick}
             disabled={isStreaming}
             aria-label="Attach images"
             title="Attach images"
           >
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-              <path d="M21.44 11.05 12.25 20.24a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 1 1 5.66 5.66L9.41 17.4a2 2 0 0 1-2.82-2.82l8.49-8.48" />
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+              <path d="M12 5v14M5 12h14" />
             </svg>
           </button>
-        )}
-        <textarea
-          ref={textareaRef}
-          value={message}
-          onChange={handleChange}
-          onKeyDown={handleKeyDown}
-          onFocus={handleTextareaFocus}
-          onBlur={handleTextareaBlur}
-          onCompositionStart={handleCompositionStart}
-          onCompositionEnd={handleCompositionEnd}
-          placeholder="Type a message... (/ for commands)"
-          rows={1}
-          aria-label="Message input"
-          data-testid="message-input"
-          autoCorrect="on"
-          autoCapitalize="sentences"
-          spellCheck={true}
-        />
-        {!hideMediaButtons && (
+        </div>
+        {!hideVoiceButton && (
           <button
             className={`voice-btn${isListening ? ' listening' : ''}`}
             onClick={handleVoiceInput}
@@ -875,14 +876,16 @@ export function InputArea() {
         {voiceError ? (
           <span className="voice-error" role="status">
             {voiceError}
-            <button
-              type="button"
-              className="voice-retry-btn"
-              onClick={() => { setVoiceError(null); handleVoiceInput() }}
-              aria-label="Retry voice input"
-            >
-              Retry
-            </button>
+            {!hideVoiceButton && (
+              <button
+                type="button"
+                className="voice-retry-btn"
+                onClick={() => { setVoiceError(null); handleVoiceInput() }}
+                aria-label="Retry voice input"
+              >
+                Retry
+              </button>
+            )}
           </span>
         ) : (
           <span className="keyboard-hint">

--- a/src/components/TopBar.test.tsx
+++ b/src/components/TopBar.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { TopBar } from './TopBar'
+import { useStore } from '../store'
+
+// The overflow menu is a presentation-only collapse of the existing header
+// controls; these tests exercise its behavior against the real Zustand store.
+
+function seedStore(partial: Record<string, unknown> = {}) {
+  useStore.setState({
+    connected: true,
+    connecting: false,
+    thinkingEnabled: false,
+    fastModeEnabled: false,
+    rightPanelOpen: false,
+    showSettings: false,
+    sessions: [],
+    currentSessionId: null,
+    // Stub out the async session patch so the Fast row has no client side effects.
+    patchCurrentSession: vi.fn().mockResolvedValue(undefined),
+    ...partial,
+  } as never)
+}
+
+function getTrigger() {
+  return screen.getByRole('button', { name: /more controls/i })
+}
+
+function openMenu() {
+  fireEvent.click(getTrigger())
+  return screen.getByRole('menu')
+}
+
+describe('TopBar overflow menu', () => {
+  beforeEach(() => {
+    seedStore()
+  })
+
+  it('renders a collapsed overflow trigger with menu semantics', () => {
+    render(<TopBar />)
+    const trigger = getTrigger()
+    expect(trigger).toHaveAttribute('aria-haspopup', 'menu')
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+
+  it('toggles the menu open and closed from the trigger', () => {
+    render(<TopBar />)
+    const trigger = getTrigger()
+
+    fireEvent.click(trigger)
+    expect(trigger).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+
+    fireEvent.click(trigger)
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+
+  it('closes the menu on Escape', () => {
+    render(<TopBar />)
+    const menu = openMenu()
+    fireEvent.keyDown(menu, { key: 'Escape' })
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+
+  it('closes the menu when the scrim is clicked', () => {
+    const { container } = render(<TopBar />)
+    openMenu()
+    const scrim = container.querySelector('.overflow-menu-scrim')
+    expect(scrim).toBeTruthy()
+    fireEvent.click(scrim as Element)
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+
+  it('reflects and toggles Thinking via store state', () => {
+    render(<TopBar />)
+    openMenu()
+    const thinking = screen.getByRole('switch', { name: /thinking/i })
+    expect(thinking).toHaveAttribute('aria-checked', 'false')
+
+    fireEvent.click(thinking)
+    expect(useStore.getState().thinkingEnabled).toBe(true)
+    expect(screen.getByRole('switch', { name: /thinking/i })).toHaveAttribute('aria-checked', 'true')
+  })
+
+  it('reflects and toggles Fast, patching the current session', () => {
+    render(<TopBar />)
+    openMenu()
+    const fast = screen.getByRole('switch', { name: /fast/i })
+    expect(fast).toHaveAttribute('aria-checked', 'false')
+
+    fireEvent.click(fast)
+    expect(useStore.getState().fastModeEnabled).toBe(true)
+    expect(useStore.getState().patchCurrentSession).toHaveBeenCalledWith({ fastMode: true })
+  })
+
+  it('toggles the Skills panel and closes the menu', () => {
+    render(<TopBar />)
+    openMenu()
+    const skills = screen.getByRole('switch', { name: /skills panel/i })
+    expect(skills).toHaveAttribute('aria-checked', 'false')
+
+    fireEvent.click(skills)
+    expect(useStore.getState().rightPanelOpen).toBe(true)
+    // Toggling the side panel navigates away, so the menu should dismiss.
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+
+  it('opens Settings and closes the menu', () => {
+    render(<TopBar />)
+    openMenu()
+    fireEvent.click(screen.getByRole('menuitem', { name: /settings/i }))
+    expect(useStore.getState().showSettings).toBe(true)
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+
+  it('keeps the menu open while flipping mode switches', () => {
+    render(<TopBar />)
+    openMenu()
+    fireEvent.click(screen.getByRole('switch', { name: /thinking/i }))
+    // Switching a mode should not dismiss the lightweight popover.
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+  })
+
+  it('shows the active indicator dot when a mode is on', () => {
+    seedStore({ thinkingEnabled: true })
+    const { container } = render(<TopBar />)
+    expect(container.querySelector('.overflow-menu-indicator')).toBeInTheDocument()
+  })
+
+  it('hides the active indicator dot when nothing is on', () => {
+    const { container } = render(<TopBar />)
+    expect(container.querySelector('.overflow-menu-indicator')).not.toBeInTheDocument()
+  })
+})

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useStore, selectSessionFastMode, selectSessionThinkingLevel } from '../store'
 
@@ -75,6 +75,58 @@ export function TopBar() {
     }
     return title || 'New Chat'
   }, [currentSession, agents])
+
+  // ----- Overflow menu (collapsed mobile header) -----
+  // All controls below reuse the existing store state/handlers; this is a
+  // presentation-only collapse of the inline header controls on narrow viewports.
+  const fastActive = fastModeEnabled || sessionFastMode
+  const anyModeActive = thinkingEnabled || fastActive || rightPanelOpen
+
+  const [menuOpen, setMenuOpen] = useState(false)
+  const menuBtnRef = useRef<HTMLButtonElement>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  const closeMenu = useCallback((restoreFocus = true) => {
+    setMenuOpen(false)
+    if (restoreFocus) menuBtnRef.current?.focus()
+  }, [])
+
+  const handleFastChange = useCallback((next: boolean) => {
+    setFastModeEnabled(next)
+    patchCurrentSession({ fastMode: next || null })
+  }, [setFastModeEnabled, patchCurrentSession])
+
+  // Focus the first menu item when the menu opens.
+  useEffect(() => {
+    if (!menuOpen) return
+    menuRef.current?.querySelector<HTMLElement>('[data-menu-item]')?.focus()
+  }, [menuOpen])
+
+  const handleMenuKeyDown = useCallback((e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Escape') {
+      e.stopPropagation()
+      closeMenu()
+      return
+    }
+    const items = Array.from(
+      menuRef.current?.querySelectorAll<HTMLElement>('[data-menu-item]') ?? []
+    )
+    if (items.length === 0) return
+    const current = items.indexOf(document.activeElement as HTMLElement)
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      items[(current + 1) % items.length]?.focus()
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      items[(current - 1 + items.length) % items.length]?.focus()
+    } else if (e.key === 'Home') {
+      e.preventDefault()
+      items[0]?.focus()
+    } else if (e.key === 'End') {
+      e.preventDefault()
+      items[items.length - 1]?.focus()
+    }
+  }, [closeMenu])
 
   return (
     <header className="top-bar" data-testid="top-bar">
@@ -178,7 +230,7 @@ export function TopBar() {
         )}
 
         <button
-          className={`panel-toggle ${rightPanelOpen ? 'active' : ''}`}
+          className={`panel-toggle skills-panel-toggle ${rightPanelOpen ? 'active' : ''}`}
           onClick={() => setRightPanelOpen(!rightPanelOpen)}
           aria-label="Toggle right panel"
           aria-pressed={rightPanelOpen}
@@ -195,6 +247,128 @@ export function TopBar() {
             <path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-2 2 2 2 0 01-2-2v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83 0 2 2 0 010-2.83l.06-.06a1.65 1.65 0 00.33-1.82 1.65 1.65 0 00-1.51-1H3a2 2 0 01-2-2 2 2 0 012-2h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 010-2.83 2 2 0 012.83 0l.06.06a1.65 1.65 0 001.82.33H9a1.65 1.65 0 001-1.51V3a2 2 0 012-2 2 2 0 012 2v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 0 2 2 0 010 2.83l-.06.06a1.65 1.65 0 00-.33 1.82V9a1.65 1.65 0 001.51 1H21a2 2 0 012 2 2 2 0 01-2 2h-.09a1.65 1.65 0 00-1.51 1z" />
           </svg>
         </button>
+
+        {/* Collapsed-header overflow menu — shown only below the md breakpoint */}
+        <div className={`overflow-menu ${menuOpen ? 'open' : ''}`}>
+          <button
+            ref={menuBtnRef}
+            className="overflow-menu-btn"
+            aria-label="More controls"
+            aria-haspopup="menu"
+            aria-expanded={menuOpen}
+            onClick={() => setMenuOpen((open) => !open)}
+          >
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="12" cy="5" r="1" />
+              <circle cx="12" cy="12" r="1" />
+              <circle cx="12" cy="19" r="1" />
+            </svg>
+            {anyModeActive && <span className="overflow-menu-indicator" aria-hidden="true" />}
+          </button>
+
+          {menuOpen && (
+            <>
+              <div className="overflow-menu-scrim" aria-hidden="true" onClick={() => closeMenu(false)} />
+              <div
+                ref={menuRef}
+                className="overflow-menu-dropdown"
+                role="menu"
+                aria-label="Header controls"
+                onKeyDown={handleMenuKeyDown}
+              >
+                <div className="overflow-menu-section-label">Message Mode</div>
+
+                <button
+                  type="button"
+                  data-menu-item
+                  role="switch"
+                  aria-checked={thinkingEnabled}
+                  className="overflow-menu-row thinking-row"
+                  onClick={() => setThinkingEnabled(!thinkingEnabled)}
+                >
+                  <span className="overflow-menu-icon-tile thinking">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+                      <path d="M12 2C8.13 2 5 5.13 5 9c0 2.38 1.19 4.47 3 5.74V17a1 1 0 001 1h6a1 1 0 001-1v-2.26c1.81-1.27 3-3.36 3-5.74 0-3.87-3.13-7-7-7z" />
+                      <path d="M9 21h6M10 19v2M14 19v2" />
+                    </svg>
+                  </span>
+                  <span className="overflow-menu-row-text">
+                    <span className="overflow-menu-row-title">Thinking</span>
+                  </span>
+                  <span className="toggle-switch" aria-hidden="true">
+                    <span className="toggle-slider" />
+                  </span>
+                </button>
+
+                <button
+                  type="button"
+                  data-menu-item
+                  role="switch"
+                  aria-checked={fastActive}
+                  className="overflow-menu-row fast-row"
+                  onClick={() => handleFastChange(!fastActive)}
+                >
+                  <span className="overflow-menu-icon-tile fast">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+                      <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />
+                    </svg>
+                  </span>
+                  <span className="overflow-menu-row-text">
+                    <span className="overflow-menu-row-title">Fast</span>
+                  </span>
+                  <span className="toggle-switch" aria-hidden="true">
+                    <span className="toggle-slider" />
+                  </span>
+                </button>
+
+                <div className="overflow-menu-divider" role="separator" />
+
+                <button
+                  type="button"
+                  data-menu-item
+                  role="switch"
+                  aria-checked={rightPanelOpen}
+                  className="overflow-menu-row"
+                  onClick={() => { setRightPanelOpen(!rightPanelOpen); closeMenu(false) }}
+                >
+                  <span className="overflow-menu-icon-tile">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                      <rect x="3" y="3" width="18" height="18" rx="2" />
+                      <path d="M15 3v18" />
+                    </svg>
+                  </span>
+                  <span className="overflow-menu-row-text">
+                    <span className="overflow-menu-row-title">Skills Panel</span>
+                  </span>
+                  <span className="toggle-switch" aria-hidden="true">
+                    <span className="toggle-slider" />
+                  </span>
+                </button>
+
+                <button
+                  type="button"
+                  data-menu-item
+                  role="menuitem"
+                  className="overflow-menu-row"
+                  onClick={() => { closeMenu(false); setShowSettings(true) }}
+                >
+                  <span className="overflow-menu-icon-tile">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                      <circle cx="12" cy="12" r="3" />
+                      <path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-2 2 2 2 0 01-2-2v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83 0 2 2 0 010-2.83l.06-.06a1.65 1.65 0 00.33-1.82 1.65 1.65 0 00-1.51-1H3a2 2 0 01-2-2 2 2 0 012-2h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 010-2.83 2 2 0 012.83 0l.06.06a1.65 1.65 0 001.82.33H9a1.65 1.65 0 001-1.51V3a2 2 0 012-2 2 2 0 012 2v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 0 2 2 0 010 2.83l-.06.06a1.65 1.65 0 00-.33 1.82V9a1.65 1.65 0 001.51 1H21a2 2 0 012 2 2 2 0 01-2 2h-.09a1.65 1.65 0 00-1.51 1z" />
+                    </svg>
+                  </span>
+                  <span className="overflow-menu-row-text">
+                    <span className="overflow-menu-row-title">Settings</span>
+                  </span>
+                  <svg className="overflow-menu-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="m9 18 6-6-6-6" />
+                  </svg>
+                </button>
+              </div>
+            </>
+          )}
+        </div>
       </div>
     </header>
   )

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -2689,12 +2689,30 @@ a {
   box-shadow: var(--glow-cyan);
 }
 
-.attach-btn {
-  width: 48px;
-  height: 48px;
-  background: var(--bg-elevated);
-  border: 1px solid var(--border-default);
-  border-radius: 50%;
+/* Composer field wraps the textarea so the attach button can dock inside it */
+.composer-field {
+  flex: 1;
+  min-width: 0;
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.composer-field textarea {
+  /* Leave room for the inline attach button docked at the right edge */
+  padding-right: 46px;
+}
+
+/* Attach (+) button: transparent, inside the field, anchored to the bottom-right */
+.attach-inline-btn {
+  position: absolute;
+  right: 6px;
+  bottom: 6px;
+  width: 36px;
+  height: 36px;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-md);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -2702,19 +2720,18 @@ a {
   transition: all var(--transition-fast);
 }
 
-.attach-btn:hover:not(:disabled) {
-  border-color: var(--accent-cyan);
+.attach-inline-btn:hover:not(:disabled) {
   color: var(--accent-cyan);
 }
 
-.attach-btn:disabled {
+.attach-inline-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }
 
-.attach-btn svg {
-  width: 20px;
-  height: 20px;
+.attach-inline-btn svg {
+  width: 22px;
+  height: 22px;
 }
 
 .send-btn:hover:not(:disabled) {
@@ -5431,9 +5448,13 @@ body.capacitor-mobile .voice-btn {
   height: 52px;
 }
 
-body.capacitor-mobile .attach-btn {
-  width: 52px;
-  height: 52px;
+body.capacitor-mobile .attach-inline-btn {
+  width: 40px;
+  height: 40px;
+}
+
+body.capacitor-mobile .composer-field textarea {
+  padding-right: 50px;
 }
 
 /* Always show delete buttons on mobile (no hover) */
@@ -5493,10 +5514,6 @@ body.capacitor-mobile.keyboard-visible .chat-area {
   }
 
   .voice-btn:hover:not(:disabled) {
-    transform: none;
-  }
-
-  .attach-btn:hover:not(:disabled) {
     transform: none;
   }
 

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -62,6 +62,7 @@
   --accent-cyan-dim: #00a3bf;
   --accent-cyan-subtle: rgba(0, 217, 255, 0.1);
   --accent-purple: #a855f7;
+  --accent-purple-subtle: rgba(168, 85, 247, 0.1);
   --accent-green: #22c55e;
   --accent-amber: #f59e0b;
   --accent-red: #ef4444;
@@ -100,6 +101,7 @@
   --accent-cyan-dim: #0369a1;
   --accent-cyan-subtle: rgba(2, 132, 199, 0.1);
   --accent-purple: #7c3aed;
+  --accent-purple-subtle: rgba(124, 58, 237, 0.1);
   --accent-green: #16a34a;
   --accent-amber: #d97706;
   --accent-red: #dc2626;
@@ -1443,6 +1445,183 @@ a {
 
 [data-theme="light"] .theme-toggle .moon-icon {
   display: none;
+}
+
+/* ===== Overflow menu (collapsed mobile header) ===== */
+/* Hidden on desktop; revealed below the md breakpoint and on capacitor-mobile. */
+.overflow-menu {
+  position: relative;
+  display: none;
+  -webkit-app-region: no-drag;
+}
+
+.overflow-menu-btn {
+  position: relative;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  transition: all var(--transition-fast);
+}
+
+.overflow-menu-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.overflow-menu-btn svg {
+  width: 20px;
+  height: 20px;
+}
+
+/* Keep the trigger above the scrim so a second tap closes the menu. */
+.overflow-menu.open .overflow-menu-btn {
+  z-index: 302;
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.overflow-menu-indicator {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent-cyan);
+  box-shadow: var(--glow-cyan);
+}
+
+.overflow-menu-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 300;
+}
+
+.overflow-menu-dropdown {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 301;
+  width: 238px;
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+  animation: overflow-menu-pop var(--transition-fast) ease;
+}
+
+@keyframes overflow-menu-pop {
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.overflow-menu-section-label {
+  padding: 6px 9px 4px;
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-secondary);
+}
+
+.overflow-menu-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  width: 100%;
+  padding: 10px 9px;
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  text-align: left;
+  transition: background var(--transition-fast);
+}
+
+.overflow-menu-row:hover {
+  background: var(--bg-hover);
+}
+
+.overflow-menu-icon-tile {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  flex-shrink: 0;
+  border-radius: var(--radius-sm);
+  background: var(--bg-deep);
+  color: var(--text-secondary);
+}
+
+.overflow-menu-icon-tile svg {
+  width: 16px;
+  height: 16px;
+}
+
+.overflow-menu-icon-tile.thinking {
+  color: var(--accent-purple);
+}
+
+.overflow-menu-icon-tile.fast {
+  color: var(--accent-cyan);
+}
+
+.overflow-menu-row-text {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  flex: 1;
+  min-width: 0;
+}
+
+.overflow-menu-row-title {
+  font-size: 0.8125rem;
+  font-weight: 500;
+}
+
+.overflow-menu-divider {
+  height: 1px;
+  margin: 4px 0;
+  background: var(--border-subtle);
+}
+
+.overflow-menu-chevron {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  color: var(--text-muted);
+}
+
+/* The in-row toggle is purely visual; it mirrors the row's aria-checked state. */
+.overflow-menu-row .toggle-switch {
+  flex-shrink: 0;
+  pointer-events: none;
+}
+
+.overflow-menu-row[aria-checked="true"] .toggle-slider {
+  background: var(--accent-cyan);
+  box-shadow: var(--glow-cyan);
+}
+
+.overflow-menu-row[aria-checked="true"] .toggle-slider::before {
+  transform: translateX(20px);
+  background: white;
+}
+
+/* Active "mode" rows get a faint accent wash. */
+.overflow-menu-row.thinking-row[aria-checked="true"] {
+  background: var(--accent-purple-subtle);
+}
+
+.overflow-menu-row.fast-row[aria-checked="true"] {
+  background: var(--accent-cyan-subtle);
 }
 
 /* ===== Chat Area ===== */
@@ -4465,6 +4644,17 @@ a.message-image-fallback:hover {
   .connection-status .status-text {
     display: none;
   }
+
+  /* Collapse the header controls into the overflow (⋮) menu. */
+  .thinking-toggle,
+  .skills-panel-toggle,
+  .settings-btn {
+    display: none;
+  }
+
+  .overflow-menu {
+    display: flex;
+  }
 }
 
 /* ===== Accessibility ===== */
@@ -5635,6 +5825,17 @@ body.capacitor-mobile .thinking-icon {
 /* Hide theme toggle on mobile - moved to Settings */
 body.capacitor-mobile .theme-toggle {
   display: none;
+}
+
+/* Collapse the header controls into the overflow (⋮) menu on native mobile. */
+body.capacitor-mobile .thinking-toggle,
+body.capacitor-mobile .skills-panel-toggle,
+body.capacitor-mobile .settings-btn {
+  display: none;
+}
+
+body.capacitor-mobile .overflow-menu {
+  display: flex;
 }
 
 /* Mobile top-bar: tighter spacing */


### PR DESCRIPTION
## Summary
Collapses the mobile chat header controls into a single overflow (⋮) menu, and bumps the release to **v1.9.0**.

On narrow/touch viewports the chat header (`TopBar`) was overcrowded — the Thinking and Fast toggles, the Skills panel button, and Settings all competed for space and the session title truncated. Below the `md` breakpoint (and on `capacitor-mobile`) these now collapse into one ⋮ menu; desktop is unchanged.

### Menu contents
- **MESSAGE MODE** — Thinking (violet) and Fast (cyan) switches with active-state accent washes; toggles stay cyan.
- **Skills Panel** toggle — reflects the right-panel state and closes the menu on tap.
- **Settings** — opens the existing settings modal.
- A cyan indicator dot marks the ⋮ whenever any mode is on or the panel is open.

Presentation only — reuses existing Zustand state/handlers, no new business logic. Adds an `--accent-purple-subtle` token and `TopBar.test.tsx` (11 tests: open/close via trigger/Esc/scrim, ARIA semantics, handler wiring, indicator-dot logic).

### Release
- `package.json` → 1.9.0; `set-android-version.js` → Android `versionCode 10900` / `versionName 1.9.0`.
- Also bundles the prior `feat(composer)` commit already on this branch.

## Verification
- `vitest run`: 74 passed / 2 skipped · `tsc --noEmit` clean · `eslint` clean · mobile build OK.
- Verified live in the browser preview (dark + light) and on the Android emulator (debug build): header collapses correctly, menu matches spec, Skills Panel closes the menu, desktop layout untouched.

Tagging `v1.9.0` after merge triggers `release.yml` → signed AAB uploaded to Play Console (production, draft).

🤖 Generated with [Claude Code](https://claude.com/claude-code)